### PR TITLE
Added notebook about output preprocessing

### DIFF
--- a/output_preprocessing.ipynb
+++ b/output_preprocessing.ipynb
@@ -1,0 +1,137 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7bc7a92d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This notebook presents a simple function mc_reduce() with which to\n",
+    "# reduce the morphological encoding of a space-delimited word to a\n",
+    "# minimal notation.\n",
+    "# Its inverse, mc_expand(), restores the canonical notation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d09ca099",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The prefixes used in the encoding of Hebrew and Syriac\n",
+    "prefixes = ['!', ']', '@']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "992c2a9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A list of output forms for testing purposes\n",
+    "output_forms = [\"BR>[\", \"B-R>CJT/\", \"!M!RXP[/T:d\", \"W:n-!J!>MR[\",\n",
+    "   \"]H]MV&JR[\", \"W-]H]CQH[\", \"!M!](H]BD&JL[/\", \"W:n-!J!](H]BDL[\",\n",
+    "   \"!!@>(T&Z@(Z&DHR[:d\", \"@>(T&C@](C&T](J&WDJ[T=\",\n",
+    "   \"D-L-!M!@(>(T&Z@(Z&DHR[/W:d\", \"D-@>(T&S@](S&T]QBL[W\",\n",
+    "   \"D-!M!@(>(T&C@](C&T]XLP[/JN\", \"!M!@(>(T&C@](C&T]BHR[/JN\",\n",
+    "   \"D-@>(T&C@(C&TBJ==[TWN\", \"@>(T&C@(C&T&J&WDJ[T=\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "73511c85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from re import sub\n",
+    "\n",
+    "# The reduction consists of removing the left-most marker from all\n",
+    "# the doubly marked prefixes and the redundant colon of the vowel\n",
+    "# pattern mark.\n",
+    "def mc_reduce(s):\n",
+    "   for c in prefixes:\n",
+    "      s = sub(f'{c}([^{c}]*{c})', r'\\1', s)\n",
+    "   return s.replace(':', '')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ea619fd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This function undoes the reduction. The hyphen in the search pattern\n",
+    "# makes sure that we stay within a single analytical word.\n",
+    "def mc_expand(s):\n",
+    "   s = sub(r'([a-z]+)', r':\\1', s)\n",
+    "   r = sub('(.)', r'\\\\\\1', ''.join(prefixes))\n",
+    "   for c in prefixes:\n",
+    "      s = sub(f'([^-{r}]*{c})', f'{c}\\\\1', s)\n",
+    "   return s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b17338e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BR>[\tBR>[\tTrue\n",
+      "B-R>CJT/\tB-R>CJT/\tTrue\n",
+      "!M!RXP[/T:d\tM!RXP[/Td\tTrue\n",
+      "W:n-!J!>MR[\tWn-J!>MR[\tTrue\n",
+      "]H]MV&JR[\tH]MV&JR[\tTrue\n",
+      "W-]H]CQH[\tW-H]CQH[\tTrue\n",
+      "!M!](H]BD&JL[/\tM!(H]BD&JL[/\tTrue\n",
+      "W:n-!J!](H]BDL[\tWn-J!(H]BDL[\tTrue\n",
+      "!!@>(T&Z@(Z&DHR[:d\t!>(T&Z@(Z&DHR[d\tTrue\n",
+      "@>(T&C@](C&T](J&WDJ[T=\t>(T&C@(C&T](J&WDJ[T=\tTrue\n",
+      "D-L-!M!@(>(T&Z@(Z&DHR[/W:d\tD-L-M!(>(T&Z@(Z&DHR[/Wd\tTrue\n",
+      "D-@>(T&S@](S&T]QBL[W\tD->(T&S@(S&T]QBL[W\tTrue\n",
+      "D-!M!@(>(T&C@](C&T]XLP[/JN\tD-M!(>(T&C@(C&T]XLP[/JN\tTrue\n",
+      "!M!@(>(T&C@](C&T]BHR[/JN\tM!(>(T&C@(C&T]BHR[/JN\tTrue\n",
+      "D-@>(T&C@(C&TBJ==[TWN\tD->(T&C@(C&TBJ==[TWN\tTrue\n",
+      "@>(T&C@(C&T&J&WDJ[T=\t>(T&C@(C&T&J&WDJ[T=\tTrue\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The boolean value in the test output indicates whether mc_expand()\n",
+    "# in fact functions as the inverse of mc_reduce().\n",
+    "for s in output_forms:\n",
+    "   r = mc_reduce(s)\n",
+    "   print(s, r, s == mc_expand(r), sep='\\t')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook presents a simple function mc_reduce() with which to reduce the morphological encoding of a space-delimited word to a minimal notation. Its inverse, mc_expand(), restores the canonical notation.